### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # TODO
 
-- MINOR: add Express-compatible middleware to handle the session propagation and re-creation on expiry
 - MINOR: add getEntryByTypeAlias when available in prod
 - MINOR: add the new bulk method to add applogs when available in prod
+- MINOR: basic robot detection with a default deviceId for them all ?
+- MINOR: ensure only one new session may be created at a time, in case of many calls happening before the first finishes
+
+# 2.1.0
+
+- MINOR: Added a middleware for Express to handle the session and deviceId propagation on server requests/responses
+- PATCH: Added the npm chip to the README
+- PATCH: Now checking against the HTTP response status (401) to recreate a session. Fixes a bug as the JSON response for this seems to have changed slightly.
 
 # 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the official [Accedo AppGrid](https://www.accedo.tv/appgrid/) SDK for No
 While AppGrid exposes a set of friendly REST APIs, this SDK is intended to provide a better integration with Node.js.
 It also encourages the use of best practices (for example: reusing the same sessionId for a client, but different clients for different devices).
 
-We follow semantic versioning, read about semver here](http://semver.org/).
+We follow [semantic versioning](http://semver.org/).
 Check the [change log](./CHANGELOG.md) to find out what changed between versions.
 
 ## Examples
@@ -39,7 +39,7 @@ You may also want to refer to the [AppGrid Rest API documentation](https://s3-us
 
 ## Installation
 
-`npm install --save-dev appgrid` (pending publication on NPM !)
+`npm install --save-dev appgrid`
 
 Then you can use the default export to get a factory:
 ```js

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ It also encourages the use of best practices (for example: reusing the same sess
 We follow [semantic versioning](http://semver.org/).
 Check the [change log](./CHANGELOG.md) to find out what changed between versions.
 
+## Features
+
+These features are provided by the manual creation of AppGrid client instances (via the default exported factory) :
+ - easy access to AppGrid APIs
+ - automatic deviceId creation when none was provided
+ - automatic session creation when none was provided
+ - automatic session re-creation when the existing one has expired
+
+An express-compatible middleware is included and adds those extras on top :
+ - automatic creation of AppGrid client instances, attached to the responses for further use
+ - automatic reuse of the deviceId through cookies (can be customized to use anything else based on requests)
+ - automatic reuse of the sessionKey through cookies (can be customized to use anything else based on requests)
+
 ## Examples
 Refer to the `examples-es6.js` file for comprehensive examples that cover all of the APIs exported by this module.
 
@@ -48,6 +61,30 @@ const appgrid = require('appgrid')
 Or, using the ES6 module syntax:
 ```js
 import appgrid from 'appgrid'
+```
+
+### Selected examples
+
+Find more details about usage in the documentation link above
+
+#### Use the middleware to persist deviceId and sessionKey via cookies
+
+```js
+const appgrid = require('appgrid');
+const express = require('express');
+
+const PORT = 3000;
+
+express()
+// place the appgrid middleware before your request handlers
+.use(appgrid.middleware.express({ appKey: '56ea6a370db1bf032c9df5cb' }))
+.get('/test', (req, res) => {
+   // access your client instance, it's already linked to the deviceId and sessionKey via cookies
+   res.locals.appgridClient.getEntryById('56ea7bd6935f75032a2fd431')
+   .then(entry => res.send(entry))
+   .catch(err => res.status(500).send('Failed to get the result'));
+})
+.listen(PORT, () => console.log(`Server is on ! Try http://localhost:${PORT}/test`));
 ```
 
 #### Create an AppGrid client instance

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AppGrid SDK for Node.js
+# AppGrid SDK for Node.js [![npm](https://img.shields.io/npm/v/appgrid.svg?maxAge=2592000)](https://www.npmjs.com/package/appgrid)
 
 ```
 *******************************************************************************

--- a/dist/bundle.umd.js
+++ b/dist/bundle.umd.js
@@ -81,7 +81,13 @@ var getFetch = function getFetch(path, config) {
   var headers = _extends({}, defaultHeaders, getExtraHeaders(config));
   var requestUrl = getRequestUrlWithQueryString(path, config);
   config.log('Sending a GET request to: ' + requestUrl + ' with the following headers', headers);
-  return fetch(requestUrl, { credentials: credentials, headers: headers });
+  return fetch(requestUrl, { credentials: credentials, headers: headers }).then(function (res) {
+    if (res.status >= 400) {
+      config.log('GET failed with status', res.status);
+      throw res;
+    }
+    return res;
+  });
 };
 
 var grab = function grab(path, config) {
@@ -142,8 +148,10 @@ var stamp$2 = stampit().methods({
   createSession: function createSession() {
     var _this = this;
 
-    // ignore the potential existing session
-    this.props.config.sessionKey = null;
+    // ignore any existing session
+    if (this.props.config.sessionKey) {
+      this.props.config.sessionKey = null;
+    }
     return grab('/session', this.props.config).then(function (json) {
       var sessionKey = json.sessionKey;
       // update the context of this client, adding the session key
@@ -168,15 +176,13 @@ var stamp$2 = stampit().methods({
 
     // existing session
     if (this.getSessionKey()) {
-      return next().then(function (json) {
-        var error = json.error;
-
-        if (error && error.status === '401') {
-          // expired - recreate one
+      return next().catch(function (res) {
+        if (res && res.status === 401) {
+          // session expired - recreate one then retry
           return _this2.createSession().then(next);
         }
-        // otherwise keep going
-        return json;
+        // otherwise propagate the failure
+        throw res;
       });
     }
     // no session - create it first, then launch the next action
@@ -665,6 +671,64 @@ var stamp$10 = stampit().methods({
 // Simply compose all the stamps in one single stamp to give access to all methods
 var stamp = stampit().compose(stamp$2, stamp$1, stamp$3, stamp$4, stamp$5, stamp$6, stamp$7, stamp$8, stamp$9, stamp$10);
 
+var cookieParser = require('cookie-parser')();
+
+var SIXTY_YEARS_IN_MS = 2147483647000;
+var COOKIE_DEVICE_ID = 'ag_d';
+var COOKIE_SESSION_KEY = 'ag_s';
+
+var defaultGetRequestInfo = function defaultGetRequestInfo(req) {
+  return { deviceId: req.cookies[COOKIE_DEVICE_ID], sessionKey: req.cookies[COOKIE_SESSION_KEY] };
+};
+var defaultOnDeviceIdGenerated = function defaultOnDeviceIdGenerated(id, res) {
+  return res.cookie(COOKIE_DEVICE_ID, id, { maxAge: SIXTY_YEARS_IN_MS, httpOnly: true });
+};
+var defaultOnSessionKeyChanged = function defaultOnSessionKeyChanged(key, res) {
+  return res.cookie(COOKIE_SESSION_KEY, key, { maxAge: SIXTY_YEARS_IN_MS, httpOnly: true });
+};
+
+// See doc in index.js where this is used
+var factory = function factory(appgrid) {
+  return function (config) {
+    var appKey = config.appKey;
+    var _config$getRequestInf = config.getRequestInfo;
+    var getRequestInfo = _config$getRequestInf === undefined ? defaultGetRequestInfo : _config$getRequestInf;
+    var _config$onDeviceIdGen = config.onDeviceIdGenerated;
+
+    var _onDeviceIdGenerated = _config$onDeviceIdGen === undefined ? defaultOnDeviceIdGenerated : _config$onDeviceIdGen;
+
+    var _config$onSessionKeyC = config.onSessionKeyChanged;
+
+    var _onSessionKeyChanged = _config$onSessionKeyC === undefined ? defaultOnSessionKeyChanged : _config$onSessionKeyC;
+
+    var log = config.log;
+
+    return function (req, res, next) {
+      return cookieParser(req, res, function () {
+        var _getRequestInfo = getRequestInfo(req);
+
+        var deviceId = _getRequestInfo.deviceId;
+        var sessionKey = _getRequestInfo.sessionKey;
+        // res.locals is a good place to store response-scoped data
+
+        res.locals.appgridClient = appgrid({
+          appKey: appKey,
+          deviceId: deviceId,
+          sessionKey: sessionKey,
+          log: log,
+          onDeviceIdGenerated: function onDeviceIdGenerated(id) {
+            return _onDeviceIdGenerated(id, res);
+          },
+          onSessionKeyChanged: function onSessionKeyChanged(key) {
+            return _onSessionKeyChanged(key, res);
+          }
+        });
+        next();
+      });
+    };
+  };
+};
+
 var noop = function noop() {};
 
 /**
@@ -687,13 +751,16 @@ var checkUsability = function checkUsability() {
 
 /**
  * Factory function to create an instance of an AppGrid client.
+ *
  * You must get an instance before accessing any of the exposed client APIs.
  * @function
  * @param  {object} config the configuration for the new instance
  * @param  {string} config.appKey the application Key
  * @param  {string} [config.deviceId] the device identifier (if not provided, a uuid will be generated instead)
  * @param  {string} [config.sessionKey] the sessionKey (note a new one may be created when not given or expired)
- * @param  {string} [config.log] a function to use to see this SDK's logs
+ * @param  {function} [config.log] a function to use to see this SDK's logs
+ * @param  {function} [config.onDeviceIdGenerated] callback to obtain the new deviceId, if one gets generated
+ * @param  {function} [config.onSessionKeyChanged] callback to obtain the sessionKey, anytime a new one gets generated
  * @return {client}        an AppGrid client tied to the given params
  * @example
  * import appgrid from 'appgrid';
@@ -710,10 +777,14 @@ var checkUsability = function checkUsability() {
 var appgrid = function appgrid(config) {
   var gid = config.gid;
   var appKey = config.appKey;
-  var sessionKey = config.sessionKey;
   var _config$log = config.log;
   var log = _config$log === undefined ? noop : _config$log;
+  var _config$onDeviceIdGen = config.onDeviceIdGenerated;
+  var onDeviceIdGenerated = _config$onDeviceIdGen === undefined ? noop : _config$onDeviceIdGen;
+  var _config$onSessionKeyC = config.onSessionKeyChanged;
+  var onSessionKeyChanged = _config$onSessionKeyC === undefined ? noop : _config$onSessionKeyC;
   var deviceId = config.deviceId;
+  var sessionKey = config.sessionKey;
   // First, check the params are OK
 
   if (!checkUsability(config)) {
@@ -722,19 +793,32 @@ var appgrid = function appgrid(config) {
   // Generate a uuid if no deviceId was given
   if (!deviceId) {
     deviceId = appgrid.generateUuid();
+    // trigger the callback
+    onDeviceIdGenerated(deviceId);
   }
 
+  var stampConfig = { deviceId: deviceId, gid: gid, appKey: appKey, log: log, onSessionKeyChanged: onSessionKeyChanged };
+  Object.defineProperty(stampConfig, 'sessionKey', {
+    set: function set(val) {
+      sessionKey = val;onSessionKeyChanged(val);
+    },
+    get: function get() {
+      return sessionKey;
+    }
+  });
+
   return stamp({
-    props: { config: { deviceId: deviceId, gid: gid, appKey: appKey, sessionKey: sessionKey, log: log } }
+    props: { config: stampConfig }
   });
 };
 
 /**
  * Generate a UUID.
+ *
  * Use this for a device/appKey tuple when you do not have a sessionKey already.
- * This utility method is not used through an appgrid client instance, but globally available
+ *
+ * This utility method is not used through an appgrid client instance, but available statically
  * @function
- * @alias appgrid.generateUuid
  * @return {string} a new UUID
  */
 appgrid.generateUuid = function () {
@@ -744,12 +828,81 @@ appgrid.generateUuid = function () {
 /**
  * Returns the range of the current hour of the day, as a string such as '01-05' for 1am to 5 am.
  * Useful for AppGrid log events.
- * This utility method is not used through an appgrid client instance, but globally available
+ *
+ * This utility method is not used through an appgrid client instance, but available statically
  * @function
- * @alias appgrid.getCurrentTimeOfDayDimValue
  * @return {string} a range of hours
  */
 appgrid.getCurrentTimeOfDayDimValue = getCurrentTimeOfDayDimValue;
+
+/**
+ * An express-compatible middleware.
+ *
+ * This uses the cookie-parser middleware, so you can also take advantage of the `req.cookies` array.
+ *
+ * This middleware takes care of creating an AppGrid client instance for each request automatically.
+ * By default, it will also reuse and persist the deviceId and sessionKey using the request and response cookies.
+ * That strategy can be changed by passing the optional callbacks,
+ * so you could make use of headers or request parameters for instance.
+ *
+ * Each instance is attached to the response object and available to the next express handlers as `res.locals.appgridClient`.
+ *
+ * This utility method is not used through an appgrid client instance, but available statically
+ * @function
+ * @param  {object} config the configuration
+ * @param  {string} config.appKey the application Key that will be used for all appgrid clients
+ * @param  {function} [config.getRequestInfo] callback that receives the request and returns an object with deviceId and sessionKey properties.
+ * @param  {function} [config.onDeviceIdGenerated] callback that receives the new deviceId (if one was not returned by getRequestInfo) and the response
+ * @param  {function} [config.onSessionKeyChanged] callback that receives the new sessionKey (anytime a new one gets generated) and the response
+ * @param  {function} [config.log] Logging function that will be passed onto the client instance
+ * @alias middleware.express
+ * @return {function} a middleware function compatible with express
+ * @example <caption>Using the default cookie strategy</caption>
+ * const appgrid = require('appgrid');
+ * const express = require('express');
+ *
+ * const PORT = 3000;
+ *
+ * express()
+ * // place the appgrid middleware before your request handlers
+ * .use(appgrid.middleware.express({ appKey: '56ea6a370db1bf032c9df5cb' }))
+ * .get('/test', (req, res) => {
+ *    // access your client instance, it's already linked to the deviceId and sessionKey via cookies
+ *    res.locals.appgridClient.getEntryById('56ea7bd6935f75032a2fd431')
+ *    .then(entry => res.send(entry))
+ *    .catch(err => res.status(500).send('Failed to get the result'));
+ * })
+ * .listen(PORT, () => console.log(`Server is on ! Try http://localhost:${PORT}/test`));
+ *
+ * @example <caption>Using custom headers to extract deviceId and sessionKey and to pass down any change</caption>
+ * const appgrid = require('appgrid_next');
+ * const express = require('express');
+ *
+ * const PORT = 3000;
+ * const HEADER_DEVICE_ID = 'X-AG-DEVICE-ID';
+ * const HEADER_SESSION_KEY = 'X-AG-SESSION-KEY';
+ *
+ * express()
+ * .use(appgrid.middleware.express({
+ *   appKey: '56ea6a370db1bf032c9df5cb',
+ *   // extract deviceId and sessionKey from custom headers
+ *   getRequestInfo: req => ({ deviceId: req.get(HEADER_DEVICE_ID), sessionKey: req.get(HEADER_SESSION_KEY)}),
+ *   // pass down any change on the deviceId (the header won't be set if unchanged compared to the value in getRequestInfo)
+ *   onDeviceIdGenerated: (id, res) => res.set(HEADER_DEVICE_ID, id),
+ *   // pass down any change on the sessionKey (the header won't be set if unchanged compared to the value in getRequestInfo)
+ *   onSessionKeyChanged: (key, res) => res.set(HEADER_SESSION_KEY, key),
+ *   log(...args) { console.log(...args) }
+ * }))
+ * .get('/test', (req, res) => {
+ *   res.locals.appgridClient.getEntryById('56ea7bd6935f75032a2fd431')
+ *   .then(entry => res.send(entry))
+ *   .catch(err => res.status(500).send('Failed to get the result'));
+ * })
+ * .listen(PORT, () => console.log(`Server is on ! Try http://localhost:${PORT}/test`));
+ */
+appgrid.middleware = {
+  express: factory(appgrid)
+};
 
 return appgrid;
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,15 +47,21 @@
                     <li class='h5'><span>Static members</span></li>
                     
                       <li><a
-                        href='#appgrid.appgrid.generateUuid'
+                        href='#appgrid.generateUuid'
                         class='regular pre-open'>
-                        .appgrid.generateUuid
+                        .generateUuid
                       </a></li>
                     
                       <li><a
-                        href='#appgrid.appgrid.getCurrentTimeOfDayDimValue'
+                        href='#appgrid.getCurrentTimeOfDayDimValue'
                         class='regular pre-open'>
-                        .appgrid.getCurrentTimeOfDayDimValue
+                        .getCurrentTimeOfDayDimValue
+                      </a></li>
+                    
+                      <li><a
+                        href='#appgrid.middleware.express'
+                        class='regular pre-open'>
+                        .middleware.express
                       </a></li>
                     
                     </ul>
@@ -362,8 +368,8 @@
   </div>
   
 
-  <p>Factory function to create an instance of an AppGrid client.
-You must get an instance before accessing any of the exposed client APIs.</p>
+  <p>Factory function to create an instance of an AppGrid client.</p>
+<p>You must get an instance before accessing any of the exposed client APIs.</p>
 
 
   <div class='pre p1 fill-light mt0'>appgrid(config: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>): client</div>
@@ -421,9 +427,23 @@ You must get an instance before accessing any of the exposed client APIs.</p>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>config.log</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]</code>
+                  <td class='break-word'><span class='code bold'>config.log</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a>]</code>
                   </td>
                   <td class='break-word'><span>a function to use to see this SDK&#x27;s logs
+</span></td>
+                </tr>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>config.onDeviceIdGenerated</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a>]</code>
+                  </td>
+                  <td class='break-word'><span>callback to obtain the new deviceId, if one gets generated
+</span></td>
+                </tr>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>config.onSessionKeyChanged</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a>]</code>
+                  </td>
+                  <td class='break-word'><span>callback to obtain the sessionKey, anytime a new one gets generated
 </span></td>
                 </tr>
               
@@ -470,11 +490,11 @@ You must get an instance before accessing any of the exposed client APIs.</p>
     <div class='py1 quiet mt1 prose-big'>Static Members</div>
     <div class="clearfix">
   
-    <div class='border-bottom' id='appgrid.appgrid.generateUuid'>
+    <div class='border-bottom' id='appgrid.generateUuid'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>appgrid.generateUuid()</span>
+            <span class='code strong strong truncate'>generateUuid()</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -482,12 +502,12 @@ You must get an instance before accessing any of the exposed client APIs.</p>
 
   
 
-  <p>Generate a UUID.
-Use this for a device/appKey tuple when you do not have a sessionKey already.
-This utility method is not used through an appgrid client instance, but globally available</p>
+  <p>Generate a UUID.</p>
+<p>Use this for a device/appKey tuple when you do not have a sessionKey already.</p>
+<p>This utility method is not used through an appgrid client instance, but available statically</p>
 
 
-  <div class='pre p1 fill-light mt0'>appgrid.generateUuid(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  <div class='pre p1 fill-light mt0'>generateUuid(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
 
   
 
@@ -525,11 +545,11 @@ This utility method is not used through an appgrid client instance, but globally
       </div>
     </div>
   
-    <div class='border-bottom' id='appgrid.appgrid.getCurrentTimeOfDayDimValue'>
+    <div class='border-bottom' id='appgrid.getCurrentTimeOfDayDimValue'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>appgrid.getCurrentTimeOfDayDimValue()</span>
+            <span class='code strong strong truncate'>getCurrentTimeOfDayDimValue()</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -538,11 +558,11 @@ This utility method is not used through an appgrid client instance, but globally
   
 
   <p>Returns the range of the current hour of the day, as a string such as &#x27;01-05&#x27; for 1am to 5 am.
-Useful for AppGrid log events.
-This utility method is not used through an appgrid client instance, but globally available</p>
+Useful for AppGrid log events.</p>
+<p>This utility method is not used through an appgrid client instance, but available statically</p>
 
 
-  <div class='pre p1 fill-light mt0'>appgrid.getCurrentTimeOfDayDimValue(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  <div class='pre p1 fill-light mt0'>getCurrentTimeOfDayDimValue(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
 
   
 
@@ -568,6 +588,178 @@ This utility method is not used through an appgrid client instance, but globally
 
   
 
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='appgrid.middleware.express'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>middleware.express(config)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>An express-compatible middleware.</p>
+<p>This uses the cookie-parser middleware, so you can also take advantage of the <code>req.cookies</code> array.</p>
+<p>This middleware takes care of creating an AppGrid client instance for each request automatically.
+By default, it will also reuse and persist the deviceId and sessionKey using the request and response cookies.
+That strategy can be changed by passing the optional callbacks,
+so you could make use of headers or request parameters for instance.</p>
+<p>Each instance is attached to the response object and available to the next express handlers as <code>res.locals.appgridClient</code>.</p>
+<p>This utility method is not used through an appgrid client instance, but available statically</p>
+
+
+  <div class='pre p1 fill-light mt0'>middleware.express(config: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>config</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>)</code> the configuration
+
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>config.appKey</span> <code class='quiet'><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+                  </td>
+                  <td class='break-word'><span>the application Key that will be used for all appgrid clients
+</span></td>
+                </tr>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>config.getRequestInfo</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a>]</code>
+                  </td>
+                  <td class='break-word'><span>callback that receives the request and returns an object with deviceId and sessionKey properties.
+</span></td>
+                </tr>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>config.onDeviceIdGenerated</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a>]</code>
+                  </td>
+                  <td class='break-word'><span>callback that receives the new deviceId (if one was not returned by getRequestInfo) and the response
+</span></td>
+                </tr>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>config.onSessionKeyChanged</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a>]</code>
+                  </td>
+                  <td class='break-word'><span>callback that receives the new sessionKey (anytime a new one gets generated) and the response
+</span></td>
+                </tr>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>config.log</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a>]</code>
+                  </td>
+                  <td class='break-word'><span>Logging function that will be passed onto the client instance
+</span></td>
+                </tr>
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">function</a></code>:
+        a middleware function compatible with express
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      <p><p>Using the default cookie strategy</p>
+</p>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> appgrid = <span class="hljs-built_in">require</span>(<span class="hljs-string">'appgrid'</span>);
+<span class="hljs-keyword">const</span> express = <span class="hljs-built_in">require</span>(<span class="hljs-string">'express'</span>);
+
+<span class="hljs-keyword">const</span> PORT = <span class="hljs-number">3000</span>;
+
+express()
+<span class="hljs-comment">// place the appgrid middleware before your request handlers</span>
+.use(appgrid.middleware.express({ appKey: <span class="hljs-string">'56ea6a370db1bf032c9df5cb'</span> }))
+.get(<span class="hljs-string">'/test'</span>, (req, res) =&gt; {
+   <span class="hljs-comment">// access your client instance, it's already linked to the deviceId and sessionKey via cookies</span>
+   res.locals.appgridClient.getEntryById(<span class="hljs-string">'56ea7bd6935f75032a2fd431'</span>)
+   .then(entry =&gt; res.send(entry))
+   .catch(err =&gt; res.status(<span class="hljs-number">500</span>).send(<span class="hljs-string">'Failed to get the result'</span>));
+})
+.listen(PORT, () =&gt; <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Server is on ! Try http://localhost:<span class="hljs-subst">${PORT}</span>/test`</span>));</pre>
+    
+      <p><p>Using custom headers to extract deviceId and sessionKey and to pass down any change</p>
+</p>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> appgrid = <span class="hljs-built_in">require</span>(<span class="hljs-string">'appgrid_next'</span>);
+<span class="hljs-keyword">const</span> express = <span class="hljs-built_in">require</span>(<span class="hljs-string">'express'</span>);
+
+<span class="hljs-keyword">const</span> PORT = <span class="hljs-number">3000</span>;
+<span class="hljs-keyword">const</span> HEADER_DEVICE_ID = <span class="hljs-string">'X-AG-DEVICE-ID'</span>;
+<span class="hljs-keyword">const</span> HEADER_SESSION_KEY = <span class="hljs-string">'X-AG-SESSION-KEY'</span>;
+
+express()
+.use(appgrid.middleware.express({
+  appKey: <span class="hljs-string">'56ea6a370db1bf032c9df5cb'</span>,
+  <span class="hljs-comment">// extract deviceId and sessionKey from custom headers</span>
+  getRequestInfo: req =&gt; ({ deviceId: req.get(HEADER_DEVICE_ID), sessionKey: req.get(HEADER_SESSION_KEY)}),
+  <span class="hljs-comment">// pass down any change on the deviceId (the header won't be set if unchanged compared to the value in getRequestInfo)</span>
+  onDeviceIdGenerated: (id, res) =&gt; res.set(HEADER_DEVICE_ID, id),
+  <span class="hljs-comment">// pass down any change on the sessionKey (the header won't be set if unchanged compared to the value in getRequestInfo)</span>
+  onSessionKeyChanged: (key, res) =&gt; res.set(HEADER_SESSION_KEY, key),
+  log(...args) { <span class="hljs-built_in">console</span>.log(...args) }
+}))
+.get(<span class="hljs-string">'/test'</span>, (req, res) =&gt; {
+  res.locals.appgridClient.getEntryById(<span class="hljs-string">'56ea7bd6935f75032a2fd431'</span>)
+  .then(entry =&gt; res.send(entry))
+  .catch(err =&gt; res.status(<span class="hljs-number">500</span>).send(<span class="hljs-string">'Failed to get the result'</span>));
+})
+.listen(PORT, () =&gt; <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Server is on ! Try http://localhost:<span class="hljs-subst">${PORT}</span>/test`</span>));</pre>
+    
   
 
   

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "source-map-support": "^0.4.2"
   },
   "dependencies": {
+    "cookie-parser": "^1.4.3",
     "isomorphic-fetch": "^2.2.1",
     "qs": "^6.2.1",
     "stampit": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appgrid",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The Official AppGrid SDK for Node.js",
   "main": "dist/bundle.umd.js",
   "jsnext:main": "dist/bundle.es6.js",

--- a/src/apiHelper.js
+++ b/src/apiHelper.js
@@ -45,7 +45,14 @@ const getFetch = (path, config) => {
   const headers = { ...defaultHeaders, ...getExtraHeaders(config) };
   const requestUrl = getRequestUrlWithQueryString(path, config);
   config.log(`Sending a GET request to: ${requestUrl} with the following headers`, headers);
-  return fetch(requestUrl, { credentials, headers });
+  return fetch(requestUrl, { credentials, headers })
+    .then(res => {
+      if (res.status >= 400) {
+        config.log('GET failed with status', res.status);
+        throw res;
+      }
+      return res;
+    });
 };
 
 export const grab = (path, config) => {

--- a/src/express.js
+++ b/src/express.js
@@ -1,0 +1,35 @@
+const cookieParser = require('cookie-parser')();
+
+const SIXTY_YEARS_IN_MS = 2147483647000;
+const COOKIE_DEVICE_ID = 'ag_d';
+const COOKIE_SESSION_KEY = 'ag_s';
+
+const defaultGetRequestInfo = (req) => ({ deviceId: req.cookies[COOKIE_DEVICE_ID], sessionKey: req.cookies[COOKIE_SESSION_KEY] });
+const defaultOnDeviceIdGenerated = (id, res) => res.cookie(COOKIE_DEVICE_ID, id, { maxAge: SIXTY_YEARS_IN_MS, httpOnly: true });
+const defaultOnSessionKeyChanged = (key, res) => res.cookie(COOKIE_SESSION_KEY, key, { maxAge: SIXTY_YEARS_IN_MS, httpOnly: true });
+
+// See doc in index.js where this is used
+const factory = (appgrid) => (config) => {
+  const {
+    appKey,
+    getRequestInfo = defaultGetRequestInfo,
+    onDeviceIdGenerated = defaultOnDeviceIdGenerated,
+    onSessionKeyChanged = defaultOnSessionKeyChanged,
+    log
+  } = config;
+  return (req, res, next) => cookieParser(req, res, () => {
+    const { deviceId, sessionKey } = getRequestInfo(req);
+    // res.locals is a good place to store response-scoped data
+    res.locals.appgridClient = appgrid({
+      appKey,
+      deviceId,
+      sessionKey,
+      log,
+      onDeviceIdGenerated: id => onDeviceIdGenerated(id, res),
+      onSessionKeyChanged: key => onSessionKeyChanged(key, res)
+    });
+    next();
+  });
+};
+
+export default factory;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import uuidLib from 'uuid';
 import stamp from './stamps/appgridClient';
 import { getCurrentTimeOfDayDimValue } from './stamps/appLog';
+import expressMwFactory from './express';
 
 const noop = () => {};
 
@@ -20,13 +21,16 @@ const checkUsability = ({ appKey, deviceId, sessionKey } = {}) =>
 
 /**
  * Factory function to create an instance of an AppGrid client.
+ *
  * You must get an instance before accessing any of the exposed client APIs.
  * @function
  * @param  {object} config the configuration for the new instance
  * @param  {string} config.appKey the application Key
  * @param  {string} [config.deviceId] the device identifier (if not provided, a uuid will be generated instead)
  * @param  {string} [config.sessionKey] the sessionKey (note a new one may be created when not given or expired)
- * @param  {string} [config.log] a function to use to see this SDK's logs
+ * @param  {function} [config.log] a function to use to see this SDK's logs
+ * @param  {function} [config.onDeviceIdGenerated] callback to obtain the new deviceId, if one gets generated
+ * @param  {function} [config.onSessionKeyChanged] callback to obtain the sessionKey, anytime a new one gets generated
  * @return {client}        an AppGrid client tied to the given params
  * @example
  * import appgrid from 'appgrid';
@@ -41,8 +45,8 @@ const checkUsability = ({ appKey, deviceId, sessionKey } = {}) =>
  * const client3 = appgrid({ appKey: 'MY_APP_KEY' });
  */
 const appgrid = (config) => {
-  const { gid, appKey, sessionKey, log = noop } = config;
-  let { deviceId } = config;
+  const { gid, appKey, log = noop, onDeviceIdGenerated = noop, onSessionKeyChanged = noop } = config;
+  let { deviceId, sessionKey } = config;
   // First, check the params are OK
   if (!checkUsability(config)) {
     throw new Error('You must provide an appKey | an appKey and a deviceId | an appKey, a deviceId and a sessionKey');
@@ -50,19 +54,28 @@ const appgrid = (config) => {
   // Generate a uuid if no deviceId was given
   if (!deviceId) {
     deviceId = appgrid.generateUuid();
+    // trigger the callback
+    onDeviceIdGenerated(deviceId);
   }
 
+  const stampConfig = { deviceId, gid, appKey, log, onSessionKeyChanged };
+  Object.defineProperty(stampConfig, 'sessionKey', {
+    set(val) { sessionKey = val; onSessionKeyChanged(val); },
+    get() { return sessionKey; }
+  });
+
   return stamp({
-    props: { config: { deviceId, gid, appKey, sessionKey, log } }
+    props: { config: stampConfig }
   });
 };
 
 /**
  * Generate a UUID.
+ *
  * Use this for a device/appKey tuple when you do not have a sessionKey already.
- * This utility method is not used through an appgrid client instance, but globally available
+ *
+ * This utility method is not used through an appgrid client instance, but available statically
  * @function
- * @alias appgrid.generateUuid
  * @return {string} a new UUID
  */
 appgrid.generateUuid = () => uuidLib.v4();
@@ -70,12 +83,80 @@ appgrid.generateUuid = () => uuidLib.v4();
 /**
  * Returns the range of the current hour of the day, as a string such as '01-05' for 1am to 5 am.
  * Useful for AppGrid log events.
- * This utility method is not used through an appgrid client instance, but globally available
+ *
+ * This utility method is not used through an appgrid client instance, but available statically
  * @function
- * @alias appgrid.getCurrentTimeOfDayDimValue
  * @return {string} a range of hours
  */
 appgrid.getCurrentTimeOfDayDimValue = getCurrentTimeOfDayDimValue;
 
+/**
+ * An express-compatible middleware.
+ *
+ * This uses the cookie-parser middleware, so you can also take advantage of the `req.cookies` array.
+ *
+ * This middleware takes care of creating an AppGrid client instance for each request automatically.
+ * By default, it will also reuse and persist the deviceId and sessionKey using the request and response cookies.
+ * That strategy can be changed by passing the optional callbacks,
+ * so you could make use of headers or request parameters for instance.
+ *
+ * Each instance is attached to the response object and available to the next express handlers as `res.locals.appgridClient`.
+ *
+ * This utility method is not used through an appgrid client instance, but available statically
+ * @function
+ * @param  {object} config the configuration
+ * @param  {string} config.appKey the application Key that will be used for all appgrid clients
+ * @param  {function} [config.getRequestInfo] callback that receives the request and returns an object with deviceId and sessionKey properties.
+ * @param  {function} [config.onDeviceIdGenerated] callback that receives the new deviceId (if one was not returned by getRequestInfo) and the response
+ * @param  {function} [config.onSessionKeyChanged] callback that receives the new sessionKey (anytime a new one gets generated) and the response
+ * @param  {function} [config.log] Logging function that will be passed onto the client instance
+ * @alias middleware.express
+ * @return {function} a middleware function compatible with express
+ * @example <caption>Using the default cookie strategy</caption>
+ * const appgrid = require('appgrid');
+ * const express = require('express');
+ *
+ * const PORT = 3000;
+ *
+ * express()
+ * // place the appgrid middleware before your request handlers
+ * .use(appgrid.middleware.express({ appKey: '56ea6a370db1bf032c9df5cb' }))
+ * .get('/test', (req, res) => {
+ *    // access your client instance, it's already linked to the deviceId and sessionKey via cookies
+ *    res.locals.appgridClient.getEntryById('56ea7bd6935f75032a2fd431')
+ *    .then(entry => res.send(entry))
+ *    .catch(err => res.status(500).send('Failed to get the result'));
+ * })
+ * .listen(PORT, () => console.log(`Server is on ! Try http://localhost:${PORT}/test`));
+ *
+ * @example <caption>Using custom headers to extract deviceId and sessionKey and to pass down any change</caption>
+ * const appgrid = require('appgrid_next');
+ * const express = require('express');
+ *
+ * const PORT = 3000;
+ * const HEADER_DEVICE_ID = 'X-AG-DEVICE-ID';
+ * const HEADER_SESSION_KEY = 'X-AG-SESSION-KEY';
+ *
+ * express()
+ * .use(appgrid.middleware.express({
+ *   appKey: '56ea6a370db1bf032c9df5cb',
+ *   // extract deviceId and sessionKey from custom headers
+ *   getRequestInfo: req => ({ deviceId: req.get(HEADER_DEVICE_ID), sessionKey: req.get(HEADER_SESSION_KEY)}),
+ *   // pass down any change on the deviceId (the header won't be set if unchanged compared to the value in getRequestInfo)
+ *   onDeviceIdGenerated: (id, res) => res.set(HEADER_DEVICE_ID, id),
+ *   // pass down any change on the sessionKey (the header won't be set if unchanged compared to the value in getRequestInfo)
+ *   onSessionKeyChanged: (key, res) => res.set(HEADER_SESSION_KEY, key),
+ *   log(...args) { console.log(...args) }
+ * }))
+ * .get('/test', (req, res) => {
+ *   res.locals.appgridClient.getEntryById('56ea7bd6935f75032a2fd431')
+ *   .then(entry => res.send(entry))
+ *   .catch(err => res.status(500).send('Failed to get the result'));
+ * })
+ * .listen(PORT, () => console.log(`Server is on ! Try http://localhost:${PORT}/test`));
+ */
+appgrid.middleware = {
+  express: expressMwFactory(appgrid)
+};
 
 export default appgrid;


### PR DESCRIPTION
MINOR: Added a middleware for Express to handle the session and deviceId propagation on server requests/responses
PATCH: Added the npm chip to the README
PATCH: Now checking against the HTTP response status (401) to recreate a session. Fixes a bug as the JSON response for this seems to have changed slightly.